### PR TITLE
bugfix: salt was silently ignored!

### DIFF
--- a/lib/password-hash.js
+++ b/lib/password-hash.js
@@ -13,7 +13,7 @@ function generateSalt(len) {
 
 function generateHash(algorithm, salt, password) {
   try {
-    var hash = crypto.createHash(algorithm, salt).update(password).digest('hex');
+    var hash = crypto.createHash(algorithm).update(password + salt).digest('hex');
     return algorithm + '$' + salt + '$' + hash;
   } catch (e) {
     throw new Error('Invalid message digest algorithm');

--- a/test/password-hash.test.js
+++ b/test/password-hash.test.js
@@ -38,7 +38,10 @@ module.exports = {
     var password = 'password123';
     var hash1 = passwordHash.generate(password);
     var hash2 = passwordHash.generate(password);
-    assert.notEqual(hash1, hash2);
+
+    // test that the actual hashes (the last 40 characters for sha1) are not equal
+    assert.notEqual(hash1.substr(-40), hash2.substr(-40));
+
     assert.ok(passwordHash.verify(password, hash1));
     assert.ok(passwordHash.verify(password, hash2));
   },


### PR DESCRIPTION
hey david,

thank you for your work on `node-password-hash`.

i found and fixed a small but critical bug:

you pass the salt as the second parameter to `crypto.createHash`:

```
var hash = crypto.createHash(algorithm, salt).update(password).digest('hex');
```

`crypto.createHash` takes only one parameter.
the salt is silently ignored and provides no security.

you probably meant to do this instead:

```
var hash = crypto.createHash(algorithm).update(password + salt).digest('hex');
```

i modified the tests to check for the bug and fixed it.
