### PR TITLE
generate() was producing the same hash independent of the salt!

### DIFF
--- a/lib/password-hash.js
+++ b/lib/password-hash.js
@@ -13,7 +13,7 @@ function generateSalt(len) {
 
 function generateHash(algorithm, salt, password) {
   try {
-    var hash = crypto.createHash(algorithm, salt).update(password).digest('hex');
+    var hash = crypto.createHmac(algorithm, salt).update(password).digest('hex');
     return algorithm + '$' + salt + '$' + hash;
   } catch (e) {
     throw new Error('Invalid message digest algorithm');


### PR DESCRIPTION
Hiya,

In running many generates() together I could see the 'hashed' password were wrong:

sha256$Folf9OAYh9pt$5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
sha256$9PFABjXvSiO2$5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
sha256$x9EfR8kvIitq$5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
sha256$XgBrfqAbdsaT$5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
sha256$HDAFbYCcWdAo$5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8

ie. the salt is 12 chars and the hash is _always_  5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8.

You've used the crypto.createHash() function rather than crypto.createHmac() which is why they're all the same. I think you actually wanted to use the latter - I figure you meant that but your fingers typed something else.

Thanks for making node-password-hash ... I hope this helps it live up to it's name a bit more. :)

Happy hacking and could you let me know when you release a new version.

Cheers,
Andy
