### PR TITLE
added an 'iterations' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Generates a hash of the required `password` argument.  Hashing behavior can be m
 
 * `algorithm` - A valid cryptographic algorithm for use with the `crypto.createHmac` function, defaults to 'sha1'.
 * `saltLength` - The length of the salt that will be generated when the password is hashed, defaults to 8.
+* `iterations` - The number of times the hashing algorithm should be applied, defaults to 1.
 
 Errors are thrown if:
 

--- a/lib/password-hash.js
+++ b/lib/password-hash.js
@@ -11,13 +11,28 @@ function generateSalt(len) {
   return salt;
 }
 
-function generateHash(algorithm, salt, password) {
+function generateHash(algorithm, salt, password, iterations) {
+  iterations = iterations || 1;
   try {
-    var hash = crypto.createHmac(algorithm, salt).update(password).digest('hex');
-    return algorithm + '$' + salt + '$' + hash;
+    var hash = password;
+    for(var i=0; i<iterations; ++i) {
+      hash = crypto.createHmac(algorithm, salt).update(hash).digest('hex');
+    }
+    
+    return algorithm + '$' + salt + '$' + iterations + '$' + hash;
   } catch (e) {
     throw new Error('Invalid message digest algorithm');
   }
+}
+
+function makeBackwardCompatible(hashedPassword) {
+  var parts = hashedPassword.split('$');
+  if(parts.length === 3) {
+    parts.splice(2,0,1);
+    hashedPassword = parts.join("$");
+  }
+  
+  return hashedPassword;
 }
 
 module.exports.generate = function(password, options) {
@@ -25,21 +40,23 @@ module.exports.generate = function(password, options) {
   options || (options = {});
   options.algorithm || (options.algorithm = 'sha1');
   options.saltLength || options.saltLength == 0 || (options.saltLength = 8);
+  options.iterations || (options.iterations = 1);
   var salt = generateSalt(options.saltLength);
-  return generateHash(options.algorithm, salt, password);
+  return generateHash(options.algorithm, salt, password, options.iterations);
 };
 
 module.exports.verify = function(password, hashedPassword) {
   if (!password || !hashedPassword) return false;
+  hashedPassword = makeBackwardCompatible(hashedPassword);
   var parts = hashedPassword.split('$');
-  if (parts.length != 3) return false;
+  if (parts.length != 4) return false;
   try {
-    return generateHash(parts[0], parts[1], password) == hashedPassword;
+    return generateHash(parts[0], parts[1], password, parts[2]) == hashedPassword;
   } catch (e) {}
   return false;
 };
 
 module.exports.isHashed = function(password) {
   if (!password) return false;
-  return password.split('$').length == 3;
+  return password.split('$').length == 4;
 }

--- a/test/password-hash.test.js
+++ b/test/password-hash.test.js
@@ -71,8 +71,8 @@ module.exports = {
     var hash = passwordHash.generate(password, { algorithm: 'md5', saltLength: len });
     assert.ok(passwordHash.verify(password, hash));
     var parts = hash.split('$');
-    assert.length(parts, 3);
-    assert.length(parts[1], len);
+    assert.equal(parts.length, 3);
+    assert.equal(parts[1].length, len);
   },
 
   'Check if password is hashed': function() {

--- a/test/password-hash.test.js
+++ b/test/password-hash.test.js
@@ -65,13 +65,27 @@ module.exports = {
     assert.equal(parts[0], 'md5');
   },
 
+  'md5 hash with 1000 iterations': function() {
+    var password = 'password123';
+    var hash = passwordHash.generate(password, { algorithm: 'md5', iterations: 1000});
+    assert.ok(passwordHash.verify(password, hash));
+    var parts = hash.split('$');
+    assert.equal(parts[0], 'md5');
+  },
+
+  'old 3 token hash should still work': function() {
+    var password = 'password123';
+    var hash = "md5$qel5rKU7$9c9fecf00e965aab1e7801da6e241112"
+    assert.ok(passwordHash.verify(password, hash));
+  },
+
   'Salt length': function() {
     var password = 'password123';
     var len = 20;
     var hash = passwordHash.generate(password, { algorithm: 'md5', saltLength: len });
     assert.ok(passwordHash.verify(password, hash));
     var parts = hash.split('$');
-    assert.equal(parts.length, 3);
+    assert.equal(parts.length, 4);
     assert.equal(parts[1].length, len);
   },
 


### PR DESCRIPTION
Based on the password hashing recommendations found here http://www.jasypt.org/howtoencryptuserpasswords.html I updated this code to allow the user to specify the number of times the hashing algorithm should be applied by setting an iterations option.  The side effect of this change is that the tokens in the final hash go from 3 parts to 4 (to include the iteration count).  I made the default iterations be 1 and provided a function that will take an old 3 part hash and convert it to a 4 part hash with iterations set to 1 so everything should be backward compatible.
