### PR TITLE
add slow equals to prevent timing attack

### DIFF
--- a/lib/password-hash.js
+++ b/lib/password-hash.js
@@ -39,6 +39,14 @@ function makeBackwardCompatible(hashedPassword) {
   return hashedPassword;
 }
 
+function slowEquals(a,b) {
+    var diff=a.length ^ b.length;
+    for(var i=0;i<a.length && i<b.length;i++){
+        diff |= a[i] ^ b[i] 
+    }
+    return diff === 0;
+}
+
 module.exports.generate = function(password, options) {
   if (typeof password != 'string') throw new Error('Invalid password');
   options || (options = {});
@@ -55,7 +63,7 @@ module.exports.verify = function(password, hashedPassword) {
   var parts = hashedPassword.split('$');
   if (parts.length != 4) return false;
   try {
-    return generateHash(parts[0], parts[1], password, parts[2]) == hashedPassword;
+    return slowEquals(generateHash(parts[0], parts[1], password, parts[2]),hashedPassword);
   } catch (e) {}
   return false;
 };


### PR DESCRIPTION
According to:https://crackstation.net/hashing-security.htm#slowequals.
We should replace "==" by slow equals to prevent timing attack.
